### PR TITLE
feat(ZH-76): 메인페이지 필터(인기순, 판매순) 컴포넌트 구현

### DIFF
--- a/src/pages/Mainpage/components/ProductFilter.tsx
+++ b/src/pages/Mainpage/components/ProductFilter.tsx
@@ -1,0 +1,71 @@
+import { PETPICK_COLORS } from '@constants/colors';
+import { TextStyles } from '@styles/textStyles';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const ProductInfo = {
+  productCount: 5,
+};
+const ProductFilter = () => {
+  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const handleFilterButtonClick = (filterType: string) => {
+    setActiveFilter((prevFilter) => (prevFilter === filterType ? null : filterType));
+  };
+  return (
+    <Wrapper>
+      <FilterLayout>
+        <TotalCount>총 {ProductInfo.productCount}개</TotalCount>
+        <FilterContainer>
+          <FilterButton onClick={() => handleFilterButtonClick('popular')}>
+            <FilterTextBox isActive={activeFilter === 'popular'}>인기순</FilterTextBox>
+          </FilterButton>
+          <FilterDivideBox></FilterDivideBox>
+          <FilterButton onClick={() => handleFilterButtonClick('sales')}>
+            <FilterTextBox isActive={activeFilter === 'sales'}>판매순</FilterTextBox>
+          </FilterButton>
+        </FilterContainer>
+      </FilterLayout>
+    </Wrapper>
+  );
+};
+
+export default ProductFilter;
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 35px 0 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const FilterLayout = styled.div`
+  width: 71vw;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+const TotalCount = styled.div`
+  ${TextStyles.subText.smallM}
+  color: ${PETPICK_COLORS.GRAY[800]}
+`;
+const FilterContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 7px;
+`;
+const FilterButton = styled.button``;
+const FilterTextBox = styled.span<{ isActive: boolean }>`
+  ${TextStyles.subText.smallM}
+  color: ${({ isActive }) =>
+    isActive ? `${PETPICK_COLORS.GRAY[500]}` : `${PETPICK_COLORS.GRAY[900]}`};
+`;
+const FilterDivideBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1px;
+  height: 10px;
+  flex-shrink: 0;
+  background-color: ${PETPICK_COLORS.GRAY[400]};
+`;

--- a/src/pages/Mainpage/index.tsx
+++ b/src/pages/Mainpage/index.tsx
@@ -1,10 +1,12 @@
 import Layout from '@layout/Layout';
 import Category from './components/Category';
+import ProductFilter from './components/ProductFilter';
 
 const MainPage = () => {
   return (
     <Layout>
       <Category />
+      <ProductFilter />
       <h1>Main Page</h1>
     </Layout>
   );


### PR DESCRIPTION
## Motivation
https://choyj1997.atlassian.net/browse/ZH-76

## Key Changes
- 상품 목록에서 필터링 버튼 클릭 시 색상 바뀌도록 구현(인기순, 판매순)
- 총 게시물 목록 갯수도 동적데이터로 구현

## 결과물
<img width="1582" alt="스크린샷 2024-10-25 오전 2 10 27" src="https://github.com/user-attachments/assets/b77755f0-805f-4387-ab43-1df269319a6e">

## To Reviewers
조그만 컴포넌트 하나 만들었습니다 !