### PR TITLE
feat(ZH-107): 마이페이지 내의 찜한 상품 UI 구현 

### DIFF
--- a/src/pages/Mypage/components/Button.tsx
+++ b/src/pages/Mypage/components/Button.tsx
@@ -1,26 +1,44 @@
 import { PETPICK_COLORS } from '@constants/colors';
-import styled from 'styled-components';
+import { TextStyles } from '@styles/textStyles';
+import styled, { CSSProp } from 'styled-components';
 
 interface IButtonProps {
   text: string;
   onClick: () => void;
   borderColor?: string;
   fontColor?: string;
+  fontStyle?: CSSProp;
 }
-const Button = ({ text, onClick, borderColor, fontColor }: IButtonProps) => {
-  const defaultBorderColor = text === '담기' ? PETPICK_COLORS.BLUE[300] : PETPICK_COLORS.GRAY[300];
-  const defaultFontColor = text === '담기' ? PETPICK_COLORS.BLUE[500] : '#000';
+const Button = ({ text, onClick, borderColor, fontColor, fontStyle }: IButtonProps) => {
+  const defaultStyles =
+    text === '담기'
+      ? {
+          borderColor: PETPICK_COLORS.BLUE[300],
+          fontColor: PETPICK_COLORS.BLUE[500],
+          fontStyle: TextStyles.body.mediumM,
+        }
+      : {
+          borderColor: PETPICK_COLORS.GRAY[300],
+          fontColor: '#000',
+          fontStyle: TextStyles.subText.smallM,
+        };
   return (
     <ButtonWrapper
       onClick={onClick}
-      $borderColor={borderColor || defaultBorderColor}
-      $fontColor={fontColor || defaultFontColor}
+      $borderColor={borderColor || defaultStyles.borderColor}
+      $fontColor={fontColor || defaultStyles.fontColor}
+      $fontStyle={fontStyle || defaultStyles.fontStyle}
     >
       {text}
     </ButtonWrapper>
   );
 };
-export const ButtonWrapper = styled.div<{ $borderColor?: string; $fontColor?: string }>`
+export const ButtonWrapper = styled.div<{
+  $borderColor?: string;
+  $fontColor?: string;
+  $fontStyle?: CSSProp;
+}>`
+  ${({ $fontStyle }) => $fontStyle};
   border-radius: 3px;
   border: 1px solid ${({ $borderColor }) => $borderColor};
   color: ${({ $fontColor }) => $fontColor};

--- a/src/pages/Mypage/components/Button.tsx
+++ b/src/pages/Mypage/components/Button.tsx
@@ -1,0 +1,37 @@
+import { PETPICK_COLORS } from '@constants/colors';
+import styled from 'styled-components';
+
+interface IButtonProps {
+  text: string;
+  onClick: () => void;
+  borderColor?: string;
+  fontColor?: string;
+}
+const Button = ({ text, onClick, borderColor, fontColor }: IButtonProps) => {
+  const defaultBorderColor = text === '담기' ? PETPICK_COLORS.BLUE[300] : PETPICK_COLORS.GRAY[300];
+  const defaultFontColor = text === '담기' ? PETPICK_COLORS.BLUE[500] : '#000';
+  return (
+    <ButtonWrapper
+      onClick={onClick}
+      $borderColor={borderColor || defaultBorderColor}
+      $fontColor={fontColor || defaultFontColor}
+    >
+      {text}
+    </ButtonWrapper>
+  );
+};
+export const ButtonWrapper = styled.div<{ $borderColor?: string; $fontColor?: string }>`
+  border-radius: 3px;
+  border: 1px solid ${({ $borderColor }) => $borderColor};
+  color: ${({ $fontColor }) => $fontColor};
+  background: #fff;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+export default Button;

--- a/src/pages/Mypage/components/OrderHistory.tsx
+++ b/src/pages/Mypage/components/OrderHistory.tsx
@@ -1,0 +1,4 @@
+const OrderHistory = () => {
+  return <div>주문내역</div>;
+};
+export default OrderHistory;

--- a/src/pages/Mypage/components/WishList.tsx
+++ b/src/pages/Mypage/components/WishList.tsx
@@ -3,7 +3,10 @@ import * as S from '../styles/WishList.style';
 const WishList = () => {
   return (
     <S.Wrapper>
-      <S.Header>찜한 상품</S.Header>
+      <S.ContentWrapper>
+        <S.Header>찜한 상품</S.Header>
+        <S.CountWrapper>전체</S.CountWrapper>
+      </S.ContentWrapper>
     </S.Wrapper>
   );
 };

--- a/src/pages/Mypage/components/WishList.tsx
+++ b/src/pages/Mypage/components/WishList.tsx
@@ -1,0 +1,10 @@
+import * as S from '../styles/WishList.style';
+
+const WishList = () => {
+  return (
+    <S.Wrapper>
+      <S.Header>찜한 상품</S.Header>
+    </S.Wrapper>
+  );
+};
+export default WishList;

--- a/src/pages/Mypage/components/WishList.tsx
+++ b/src/pages/Mypage/components/WishList.tsx
@@ -1,11 +1,59 @@
+import { IProductInfo } from '@types';
 import * as S from '../styles/WishList.style';
+import WishListItem from './WishListItem';
 
 const WishList = () => {
+  const ProductInfo: IProductInfo[] = [
+    {
+      productId: 1,
+      sellerId: 1,
+      categoryId: 1,
+      productTitle: '강아지가 먹을 수 있는 닭고기',
+      productCnt: 1,
+      productPrice: 10000,
+      productType: 'DOG',
+      productStatus: 'ON',
+      productSale: 10,
+      sellerStoreName: '윤일이네 농장',
+      productImageUrl: 'https://cdn.pixabay.com/photo/2016/12/13/05/15/puppy-1903313_960_720.jpg',
+    },
+    {
+      productId: 1,
+      sellerId: 1,
+      categoryId: 1,
+      productTitle: '강아지가 먹을 수 있는 닭고기',
+      productCnt: 1,
+      productPrice: 10000,
+      productType: 'DOG',
+      productStatus: 'ON',
+      productSale: 10,
+      sellerStoreName: '윤일이네 농장',
+      productImageUrl: 'https://cdn.pixabay.com/photo/2016/12/13/05/15/puppy-1903313_960_720.jpg',
+    },
+    {
+      productId: 1,
+      sellerId: 1,
+      categoryId: 1,
+      productTitle: '강아지가 먹을 수 있는 닭고기',
+      productCnt: 1,
+      productPrice: 10000,
+      productType: 'DOG',
+      productStatus: 'ON',
+      productSale: 10,
+      sellerStoreName: '윤일이네 농장',
+      productImageUrl: 'https://cdn.pixabay.com/photo/2016/12/13/05/15/puppy-1903313_960_720.jpg',
+    },
+  ];
   return (
     <S.Wrapper>
       <S.ContentWrapper>
         <S.Header>찜한 상품</S.Header>
-        <S.CountWrapper>전체</S.CountWrapper>
+        <S.CountWrapper>전체 {ProductInfo.length}개</S.CountWrapper>
+        <S.ProductList>
+          {ProductInfo.map((product) => (
+            <WishListItem productInfo={product} />
+          ))}
+        </S.ProductList>
       </S.ContentWrapper>
     </S.Wrapper>
   );

--- a/src/pages/Mypage/components/WishListItem.tsx
+++ b/src/pages/Mypage/components/WishListItem.tsx
@@ -1,0 +1,22 @@
+import { IProductInfo } from '@types';
+import * as S from '../styles/WishListItem.style';
+
+interface IProductProps {
+  productInfo: IProductInfo;
+}
+const WishListItem = ({ productInfo }: IProductProps) => {
+  return (
+    <S.Wrapper>
+      <S.ProductImage src={productInfo.productImageUrl} />
+      <S.DescriptionWrapper>
+        <S.SellerName>{productInfo.sellerStoreName}</S.SellerName>
+        <S.ProductName>{productInfo.productTitle}</S.ProductName>
+        <S.PriceWrapper>
+          <S.ProductSalePercent>{productInfo.productSale}%</S.ProductSalePercent>
+          <S.ProductSalePrice>{productInfo.productPrice}원</S.ProductSalePrice>
+        </S.PriceWrapper>
+      </S.DescriptionWrapper>
+    </S.Wrapper>
+  );
+};
+export default WishListItem;

--- a/src/pages/Mypage/components/WishListItem.tsx
+++ b/src/pages/Mypage/components/WishListItem.tsx
@@ -1,5 +1,6 @@
 import { IProductInfo } from '@types';
 import * as S from '../styles/WishListItem.style';
+import Button from './Button';
 
 interface IProductProps {
   productInfo: IProductInfo;
@@ -15,6 +16,10 @@ const WishListItem = ({ productInfo }: IProductProps) => {
           <S.ProductSalePercent>{productInfo.productSale}%</S.ProductSalePercent>
           <S.ProductSalePrice>{productInfo.productPrice}원</S.ProductSalePrice>
         </S.PriceWrapper>
+        <S.ButtonsWrapper>
+          <Button text="삭제하기" onClick={() => console.log('삭제하기')} />
+          <Button text="담기" onClick={() => console.log('담기')} />
+        </S.ButtonsWrapper>
       </S.DescriptionWrapper>
     </S.Wrapper>
   );

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -14,8 +14,18 @@ const Mypage = () => {
 
   return (
     <Layout>
-      <button onClick={() => handleSelectComponent('whishList')}>찜한 상품</button>
-      <button onClick={() => handleSelectComponent('orderHistory')}>주문내역</button>
+      <button
+        onClick={() => handleSelectComponent('whishList')}
+        style={{ width: '100px', border: '1px solid' }}
+      >
+        찜한 상품
+      </button>
+      <button
+        onClick={() => handleSelectComponent('orderHistory')}
+        style={{ width: '100px', border: '1px solid' }}
+      >
+        주문내역
+      </button>
       <div>{selectedComponent === 'whishList' ? <WishList /> : <OrderHistory />}</div>
     </Layout>
   );

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -5,7 +5,7 @@ import OrderHistory from './components/OrderHistory';
 
 const Mypage = () => {
   const [selectedComponent, setSelectedComponent] = useState<'whishList' | 'orderHistory' | null>(
-    null,
+    'whishList',
   );
 
   const handleSelectComponent = (component: 'whishList' | 'orderHistory') => {

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,7 +1,24 @@
 import Layout from '@layout/Layout';
+import { useState } from 'react';
+import WishList from './components/WishList';
+import OrderHistory from './components/OrderHistory';
 
 const Mypage = () => {
-  return <Layout>Mypage</Layout>;
+  const [selectedComponent, setSelectedComponent] = useState<'whishList' | 'orderHistory' | null>(
+    null,
+  );
+
+  const handleSelectComponent = (component: 'whishList' | 'orderHistory') => {
+    setSelectedComponent(component);
+  };
+
+  return (
+    <Layout>
+      <button onClick={() => handleSelectComponent('whishList')}>찜한 상품</button>
+      <button onClick={() => handleSelectComponent('orderHistory')}>주문내역</button>
+      <div>{selectedComponent === 'whishList' ? <WishList /> : <OrderHistory />}</div>
+    </Layout>
+  );
 };
 
 export default Mypage;

--- a/src/pages/Mypage/styles/WishList.style.ts
+++ b/src/pages/Mypage/styles/WishList.style.ts
@@ -5,11 +5,26 @@ import { PETPICK_COLORS } from '@constants/colors';
 export const Wrapper = styled.div`
   max-width: 745px;
   width: 100%;
-  background: pink;
   display: flex;
   justify-content: center;
+  margin: 0 auto;
+  border: 1px solid ${PETPICK_COLORS.GRAY[200]};
+  border-radius: 8px;
 `;
-export const Header = styled.div`
+export const ContentWrapper = styled.div`
   max-width: 718px;
   width: 100%;
+  padding: 0 24px;
+`;
+export const Header = styled.div`
+  width: 100%;
+  padding: 25px 0;
+  ${TextStyles.subTitle.largeSB};
+  border-bottom: 1px solid ${PETPICK_COLORS.GRAY[300]};
+`;
+export const CountWrapper = styled.div`
+  ${TextStyles.subText.smallM};
+  color: ${PETPICK_COLORS.GRAY[900]};
+  padding: 7px 0;
+  margin-top: 11px;
 `;

--- a/src/pages/Mypage/styles/WishList.style.ts
+++ b/src/pages/Mypage/styles/WishList.style.ts
@@ -7,7 +7,7 @@ export const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-  margin: 0 auto;
+  margin: 45px auto;
   border: 1px solid ${PETPICK_COLORS.GRAY[200]};
   border-radius: 8px;
 `;
@@ -27,4 +27,13 @@ export const CountWrapper = styled.div`
   color: ${PETPICK_COLORS.GRAY[900]};
   padding: 7px 0;
   margin-top: 11px;
+`;
+export const ProductList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  padding: 22px 0;
+`;
+export const ProductItem = styled.div`
+  display: flex;
 `;

--- a/src/pages/Mypage/styles/WishList.style.ts
+++ b/src/pages/Mypage/styles/WishList.style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { TextStyles } from '@styles/textStyles';
+import { PETPICK_COLORS } from '@constants/colors';
+
+export const Wrapper = styled.div`
+  max-width: 745px;
+  width: 100%;
+  background: pink;
+  display: flex;
+  justify-content: center;
+`;
+export const Header = styled.div`
+  max-width: 718px;
+  width: 100%;
+`;

--- a/src/pages/Mypage/styles/WishListItem.style.ts
+++ b/src/pages/Mypage/styles/WishListItem.style.ts
@@ -1,0 +1,38 @@
+import { PETPICK_COLORS } from '@constants/colors';
+import { TextStyles } from '@styles/textStyles';
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 108px;
+  display: flex;
+  gap: 17px;
+`;
+export const ProductImage = styled.img`
+  width: 91px;
+  object-fit: cover;
+  border-radius: 4px;
+`;
+export const DescriptionWrapper = styled.div`
+  width: 100%;
+`;
+export const SellerName = styled.div`
+  ${TextStyles.subText.smallR}
+  color: ${PETPICK_COLORS.GRAY[500]};
+`;
+export const ProductName = styled.div`
+  ${TextStyles.body.mediumM};
+  color: ${PETPICK_COLORS.GRAY[800]};
+`;
+export const PriceWrapper = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+export const ProductSalePercent = styled.div`
+  ${TextStyles.subText.smallSB};
+  color: ${PETPICK_COLORS.RED[200]};
+`;
+export const ProductSalePrice = styled.div`
+  ${TextStyles.subText.smallSB};
+  color: ${PETPICK_COLORS.GRAY[900]};
+`;

--- a/src/pages/Mypage/styles/WishListItem.style.ts
+++ b/src/pages/Mypage/styles/WishListItem.style.ts
@@ -12,6 +12,9 @@ export const ProductImage = styled.img`
   width: 91px;
   object-fit: cover;
   border-radius: 4px;
+  &:hover {
+    cursor: pointer;
+  }
 `;
 export const DescriptionWrapper = styled.div`
   width: 100%;
@@ -35,4 +38,11 @@ export const ProductSalePercent = styled.div`
 export const ProductSalePrice = styled.div`
   ${TextStyles.subText.smallSB};
   color: ${PETPICK_COLORS.GRAY[900]};
+`;
+export const ButtonsWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 20px;
+  heihgt: 48px;
+  padding-top: 6px;
 `;


### PR DESCRIPTION
## Motivation
> 구체적인 기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.
> PR에는 간략하게 작성해주세요

https://choyj1997.atlassian.net/browse/ZH-107

~를 사용해 ~를 구현했습니다.

- 임시 버튼을 추가하여 찜한 상품, 주문 내역 컴포넌트가 보이도록 설정했습니다.
- 피그마에서는 마켓컬리 UI가 적용되어 있어 메인페이지 UI를 참고하여 상품 정보를 임의로 수정했습니다.

## Key Changes
> 이전 코드와 변경된 점, 왜 변경했는 지 구체적으로 작성해주세요

~가 변경되었습니다.

## 결과물
> 스크린샷 혹은 녹화본 GIF 파일을 올려주세요

## To Reviewers
> 리뷰어들이 중점적으로 검토할 사안에 대해 작성해주세요
![image](https://github.com/user-attachments/assets/afe85eb3-b195-41e2-ab20-26816e43598c)


~를 중점으로 보면서 검토해주세요