### PR TITLE
feat(ZH-128): 상세페이지 API 부착

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,11 +1,1 @@
-import axios from 'axios';
-
-const instance = axios.create({
-  baseURL: 'http://localhost:8080',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-});
-
-export default instance;
+export * from './product';

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const instance = axios.create({
+  baseURL: 'https://back.petpick.store/api/v1',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+export default instance;

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -1,0 +1,6 @@
+import instance from './instance';
+
+export const fetchProductDetails = async (productId) => {
+  const response = await instance.get(`products/${productId}`);
+  return response.data;
+};

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -1,6 +1,6 @@
 import instance from './instance';
 
-export const fetchProductDetails = async (productId) => {
+export const fetchProductDetails = async (productId: number) => {
   const response = await instance.get(`products/${productId}`);
   return response.data;
 };

--- a/src/pages/Detailpage/components/ProductBasicInfo.tsx
+++ b/src/pages/Detailpage/components/ProductBasicInfo.tsx
@@ -3,14 +3,16 @@ import * as S from '../styles/ProductBasicInfo.style';
 export const ProductBasicInfo = ({ productInfo }) => (
   <div>
     <S.ProductTitle>
-      [{productInfo.sellerStoreName}] {productInfo.productTitle}
+      [{productInfo.seller.sellerStoreName}] {productInfo.productName}
     </S.ProductTitle>
     <S.ProductTitleInfo> 40년 전통의 부산식 떡볶이</S.ProductTitleInfo>
 
     <div>
       <S.PriceContainer>
         <S.DiscountText>{productInfo.productSale}%</S.DiscountText>
-        <S.DiscountPrice>7,560</S.DiscountPrice>
+        {productInfo.productSale !== 0 && (
+          <S.DiscountPrice>{productInfo.productPrice / productInfo.productSale}</S.DiscountPrice>
+        )}
         <S.PriceText>원</S.PriceText>
       </S.PriceContainer>
       <S.PriceBox>

--- a/src/pages/Detailpage/components/PurchaseOptions.tsx
+++ b/src/pages/Detailpage/components/PurchaseOptions.tsx
@@ -6,8 +6,7 @@ export const PurchaseOptions = ({
   handlePlusClick,
   handleMinusClick,
 }) => {
-  // const isThrough = true;
-  // const isDiscounted = true;
+  const discountedPrice = productInfo.productPrice * (1 - productInfo.productSale / 100);
   return (
     <S.PurchaseContainer>
       <S.InfoContainer>
@@ -16,7 +15,7 @@ export const PurchaseOptions = ({
           <S.InfoText>
             <S.SelectLayout>
               <div>
-                [{productInfo.sellerStoreName}] {productInfo.productTitle}
+                [{productInfo.seller.sellerStoreName}] {productInfo.productName}
               </div>
               <S.SelectContainer>
                 <S.IncreaseButton>
@@ -29,11 +28,13 @@ export const PurchaseOptions = ({
                   </button>
                 </S.IncreaseButton>
                 <S.SelectPriceContainer>
-                  <S.PriceSpan isThrough={true} isDiscounted={false}>
-                    {productInfo.productPrice}원
-                  </S.PriceSpan>
+                  {productInfo.productSale !== 0 && (
+                    <S.PriceSpan isThrough={true} isDiscounted={true}>
+                      {discountedPrice}
+                    </S.PriceSpan>
+                  )}
                   <S.PriceSpan isThrough={false} isDiscounted={false}>
-                    7,560원
+                    {productInfo.productPrice}원
                   </S.PriceSpan>
                 </S.SelectPriceContainer>
               </S.SelectContainer>

--- a/src/pages/Detailpage/components/PurchaseOptions.tsx
+++ b/src/pages/Detailpage/components/PurchaseOptions.tsx
@@ -1,3 +1,4 @@
+import { addCommaToPrice } from '@utils/addCommaToPrice';
 import * as S from '../styles/PurchaseOptions.style';
 import { Minus, Plus } from '@assets/svg';
 export const PurchaseOptions = ({
@@ -6,7 +7,9 @@ export const PurchaseOptions = ({
   handlePlusClick,
   handleMinusClick,
 }) => {
-  const discountedPrice = productInfo.productPrice * (1 - productInfo.productSale / 100);
+  const discountedPrice = addCommaToPrice(
+    productInfo.productPrice * (1 - productInfo.productSale / 100),
+  );
   return (
     <S.PurchaseContainer>
       <S.InfoContainer>

--- a/src/pages/Detailpage/hooks/useGetProductDetails.ts
+++ b/src/pages/Detailpage/hooks/useGetProductDetails.ts
@@ -1,0 +1,29 @@
+import { fetchProductDetails } from '@apis';
+import { IProductInfo } from '@types';
+import { useEffect, useState } from 'react';
+
+const useGetProductDetails = (productId: number) => {
+  const [productInfo, setProductInfo] = useState<IProductInfo | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const loadProductDetails = async () => {
+      try {
+        setIsLoading(true);
+        const response = await fetchProductDetails(productId);
+        setProductInfo(response);
+        setIsLoading(false);
+      } catch (err) {
+        setError(err as Error); // 에러 타입 단언
+        console.error('Failed to fetch product details:', err);
+      }
+    };
+
+    loadProductDetails();
+  }, [productId]);
+
+  return { productInfo, error, isLoading };
+};
+
+export default useGetProductDetails;

--- a/src/pages/Detailpage/hooks/useGetProductDetails.ts
+++ b/src/pages/Detailpage/hooks/useGetProductDetails.ts
@@ -6,7 +6,6 @@ const useGetProductDetails = (productId: number) => {
   const [productInfo, setProductInfo] = useState<IProductInfo | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean | null>(null);
-
   useEffect(() => {
     const loadProductDetails = async () => {
       try {

--- a/src/pages/Detailpage/index.tsx
+++ b/src/pages/Detailpage/index.tsx
@@ -1,6 +1,6 @@
 import Layout from '@layouts/Layout';
 import * as S from './styles/index.style';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ProductImage } from './components/ProductImage';
 import { ProductBasicInfo } from './components/ProductBasicInfo';
 import { ProductAdditionalInfo } from './components/ProductAdditionalInfo';
@@ -9,16 +9,14 @@ import Like from '@assets/svg/Like';
 import LikeFill from '@assets/svg/LikeFill';
 import Bell from '@assets/svg/Bell';
 import { ProductDescription } from './components/ProductDescription';
-import { fetchProductDetails } from '@apis';
-import { IProductInfo } from '@types';
-import { useParams } from 'react-router-dom';
+import useGetProductDetails from './hooks/useGetProductDetails';
+import Loading from '@components/Loading';
 
-const DetailPage = () => {
-  const [productInfo, setProductInfo] = useState<IProductInfo | null>(null);
-  const [error, setError] = useState(null);
+const DetailPage = (productId: number) => {
+  const { productInfo, error, isLoading } = useGetProductDetails(productId);
+
   const [liked, setLiked] = useState(false);
   const [productCount, setProductCount] = useState(1);
-  const { productId } = useParams();
 
   const handleLikeClick = () => {
     setLiked(!liked);
@@ -34,21 +32,9 @@ const DetailPage = () => {
       setProductCount(productCount - 1);
     }
   };
+  if (error) return <p>Error: {error.message}</p>;
+  if (isLoading) return <Loading />;
 
-  useEffect(() => {
-    const loadProductDetails = async () => {
-      try {
-        const response = await fetchProductDetails(productId);
-        setProductInfo(response);
-        console.log(response);
-      } catch (err) {
-        setError(err);
-        console.error('Failed to fetch product details:', err);
-      }
-    };
-
-    loadProductDetails();
-  }, [productId]);
   return (
     <Layout footerVisible={true}>
       {productInfo ? (
@@ -82,7 +68,7 @@ const DetailPage = () => {
           <ProductDescription productInfo={productInfo} />
         </S.DetailLayout>
       ) : (
-        <p>Loading...</p>
+        <Loading />
       )}
     </Layout>
   );

--- a/src/pages/Detailpage/index.tsx
+++ b/src/pages/Detailpage/index.tsx
@@ -1,7 +1,6 @@
-import { IProductInfo } from '@types';
 import Layout from '@layouts/Layout';
 import * as S from './styles/index.style';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ProductImage } from './components/ProductImage';
 import { ProductBasicInfo } from './components/ProductBasicInfo';
 import { ProductAdditionalInfo } from './components/ProductAdditionalInfo';
@@ -10,10 +9,16 @@ import Like from '@assets/svg/Like';
 import LikeFill from '@assets/svg/LikeFill';
 import Bell from '@assets/svg/Bell';
 import { ProductDescription } from './components/ProductDescription';
+import { fetchProductDetails } from '@apis';
+import { IProductInfo } from '@types';
+import { useParams } from 'react-router-dom';
 
 const DetailPage = () => {
+  const [productInfo, setProductInfo] = useState<IProductInfo | null>(null);
+  const [error, setError] = useState(null);
   const [liked, setLiked] = useState(false);
   const [productCount, setProductCount] = useState(1);
+  const { productId } = useParams();
 
   const handleLikeClick = () => {
     setLiked(!liked);
@@ -30,50 +35,55 @@ const DetailPage = () => {
     }
   };
 
-  const ProductInfo: IProductInfo = {
-    productId: 1,
-    sellerId: 1,
-    categoryId: 1,
-    productTitle: '사료1',
-    productCnt: 1,
-    productPrice: 10000,
-    productType: 'DOG',
-    productStatus: 'ON',
-    productSale: 10,
-    productImageUrl: '@assets/svg/test.jpg',
-    sellerStoreName: '효린이네 제주농장',
-  };
+  useEffect(() => {
+    const loadProductDetails = async () => {
+      try {
+        const response = await fetchProductDetails(productId);
+        setProductInfo(response);
+        console.log(response);
+      } catch (err) {
+        setError(err);
+        console.error('Failed to fetch product details:', err);
+      }
+    };
+
+    loadProductDetails();
+  }, [productId]);
   return (
-    <Layout>
-      <S.DetailLayout>
-        <S.ProductContainer>
-          <ProductImage imageUrl={ProductInfo.productImageUrl} />
-          <S.ProductInfoContainer>
-            <ProductBasicInfo productInfo={ProductInfo} />
-            <ProductAdditionalInfo sellerStoreName={ProductInfo.sellerStoreName} />
-            <PurchaseOptions
-              productInfo={ProductInfo}
-              productCount={productCount}
-              handlePlusClick={handlePlusClick}
-              handleMinusClick={handleMinusClick}
-            />
-            <S.ActionButtonContainer>
-              <S.ActionButtons onClick={handleLikeClick}>
-                {liked ? (
-                  <Like width="32px" height="32px" />
-                ) : (
-                  <LikeFill width="32px" height="32px" />
-                )}
-              </S.ActionButtons>
-              <S.ActionButtons>
-                <Bell width="32px" height="32px" />
-              </S.ActionButtons>
-              <S.ActionGoToCartButton>장바구니 담기</S.ActionGoToCartButton>
-            </S.ActionButtonContainer>
-          </S.ProductInfoContainer>
-        </S.ProductContainer>
-        <ProductDescription productInfo={ProductInfo} />
-      </S.DetailLayout>
+    <Layout footerVisible={true}>
+      {productInfo ? (
+        <S.DetailLayout>
+          <S.ProductContainer>
+            <ProductImage imageUrl={productInfo.productImg.productImgUrl} />
+            <S.ProductInfoContainer>
+              <ProductBasicInfo productInfo={productInfo} />
+              <ProductAdditionalInfo sellerStoreName={productInfo.seller.sellerStoreName} />
+              <PurchaseOptions
+                productInfo={productInfo}
+                productCount={productCount}
+                handlePlusClick={handlePlusClick}
+                handleMinusClick={handleMinusClick}
+              />
+              <S.ActionButtonContainer>
+                <S.ActionButtons onClick={handleLikeClick}>
+                  {liked ? (
+                    <Like width="32px" height="32px" />
+                  ) : (
+                    <LikeFill width="32px" height="32px" />
+                  )}
+                </S.ActionButtons>
+                <S.ActionButtons>
+                  <Bell width="32px" height="32px" />
+                </S.ActionButtons>
+                <S.ActionGoToCartButton>장바구니 담기</S.ActionGoToCartButton>
+              </S.ActionButtonContainer>
+            </S.ProductInfoContainer>
+          </S.ProductContainer>
+          <ProductDescription productInfo={productInfo} />
+        </S.DetailLayout>
+      ) : (
+        <p>Loading...</p>
+      )}
     </Layout>
   );
 };

--- a/src/pages/Detailpage/index.tsx
+++ b/src/pages/Detailpage/index.tsx
@@ -11,9 +11,11 @@ import Bell from '@assets/svg/Bell';
 import { ProductDescription } from './components/ProductDescription';
 import useGetProductDetails from './hooks/useGetProductDetails';
 import Loading from '@components/Loading';
+import { useParams } from 'react-router-dom';
 
-const DetailPage = (productId: number) => {
-  const { productInfo, error, isLoading } = useGetProductDetails(productId);
+const DetailPage = () => {
+  const { productId } = useParams();
+  const { productInfo, error, isLoading } = useGetProductDetails(Number(productId));
 
   const [liked, setLiked] = useState(false);
   const [productCount, setProductCount] = useState(1);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,16 +3,29 @@ type ProductStatus = 'ON' | 'OFF' | 'SOLDOUT';
 
 export interface IProductInfo {
   productId: number;
-  sellerId: number;
-  categoryId: number;
-  productTitle: string;
-  productCnt: number;
+  productName: string;
+  seller: {
+    sellerId: number;
+    sellerStoreName: string;
+    sellerNumber: string;
+    sellerAddr: string;
+    sellerAddrDetail: string;
+  };
+  productStatus: 'ON';
+  likes: {
+    likesCount: number;
+  };
+
   productPrice: number;
-  productType: ProductType;
-  productStatus: ProductStatus;
+  productShare: number;
   productSale: number;
-  productImageUrl: string;
-  sellerStoreName: string;
+  productCnt: number;
+  productImg: {
+    productImgId: number;
+    productImgThumb: number;
+    productImgUrl: string;
+    productImgName: string;
+  };
 }
 export interface IOrderInfo {
   orderDate: string;


### PR DESCRIPTION
## Motivation
https://choyj1997.atlassian.net/browse/ZH-128

## Key Changes
- 상품 상세 페이지 API 부착
- 필요한 API는 index.ts에서 불러와서 사용합니다.

## 결과물
<img width="1538" alt="스크린샷 2024-11-01 오전 12 38 08" src="https://github.com/user-attachments/assets/58fa52fc-f915-43e4-b1bb-af74c68c150e">

## To Reviewers
- 파일을 따로 나눠서 api를 불러와도 
해당 페이지 내에서 useEffect를 사용하고 useState를 사용하게 되는데 이 방식이 맞을까요 ?
아니면 다른 방식이 있다면 피드백 주시면 적용하겠습니다🥹