### PR TITLE
feat(ZH-96): 로그인 로직 미구현으로 인해 임시 API에 대한 API 부착

### DIFF
--- a/src/apis/like.ts
+++ b/src/apis/like.ts
@@ -1,5 +1,11 @@
 import instance from './instance';
 
-export const toggleLike = (productId: number) => {
-  return instance.get(`/products/${productId}/like`);
+export const fetchToggleLike = (productId: number) => {
+  return instance.post(`/products/${productId}/like`);
+};
+
+export const fetchWishList = (userId: number, productId: number) => {
+  return instance.get(`/user/${userId}/likes`, {
+    data: { productId },
+  });
 };

--- a/src/apis/like.ts
+++ b/src/apis/like.ts
@@ -1,11 +1,13 @@
 import instance from './instance';
 
-export const fetchToggleLike = (productId: number) => {
-  return instance.post(`/products/${productId}/like`);
+export const fetchToggleLike = (productId: number, userId: number) => {
+  console.log('API 호출하기 ! productId ->', productId, 'userId ->', userId); // 로그 추가
+  return instance.post(`/products/${productId}/like`, {
+    userId,
+  });
 };
 
-export const fetchWishList = (userId: number, productId: number) => {
-  return instance.get(`/user/${userId}/likes`, {
-    data: { productId },
-  });
+export const fetchWishList = (userId: number) => {
+  console.log('API 호출하기 ! userId ->', userId); // 로그 추가
+  return instance.get(`/user/${userId}/likes`);
 };

--- a/src/pages/Detailpage/index.tsx
+++ b/src/pages/Detailpage/index.tsx
@@ -13,13 +13,13 @@ import useGetProductDetails from './hooks/useGetProductDetails';
 import Loading from '@components/Loading';
 import { useParams } from 'react-router-dom';
 import { fetchToggleLike, fetchWishList } from '@apis';
-import { useUserStore } from '@store/userStore';
 
 const DetailPage = () => {
   const { productId } = useParams();
   const { productInfo, error, isLoading } = useGetProductDetails(Number(productId));
   const [productCount, setProductCount] = useState(1);
-  const { userId } = useUserStore();
+  // const { userId } = useUserStore();
+  const userId = 1; // 임시데이터 1
 
   const [liked, setLiked] = useState(false);
 
@@ -28,23 +28,27 @@ const DetailPage = () => {
     const loadProductLikes = async () => {
       try {
         if (userId !== null) {
-          const response = await fetchWishList(userId, Number(productId));
+          const response = await fetchWishList(userId);
           const likedProducts = response.data; // 좋아요한 상품 목록 데이터
-          setLiked(likedProducts.includes(Number(productId)));
+          setLiked(likedProducts.includes(Number(productId))); // productId가 목록에 있는지 확인
         }
       } catch (err) {
-        console.error('Failed to fetch product details:', err);
+        console.error('상품 정보를 가져오는데 실패했습니다:', err);
       }
     };
     loadProductLikes();
   }, [productId, userId]);
 
   const handleLikeClick = async () => {
+    console.log('Like button clicked!'); // 클릭이 감지되는지 확인
     try {
-      await fetchToggleLike(Number(productId));
-      setLiked(!liked); // 로컬 상태를 토글하여 즉시 UI 반영
+      if (userId != null) {
+        await fetchToggleLike(Number(productId), userId);
+        setLiked(!liked); // 로컬 상태를 토글하여 즉시 UI 반영
+        console.log('좋아요 상태 API 호출 성공.'); // API 호출 여부 확인
+      }
     } catch (err) {
-      console.error('Failed to update wishlist:', err);
+      console.error('찜한 상품 정보를 가져오는데 실패했습니다::', err);
     }
   };
 


### PR DESCRIPTION
## Motivation
https://choyj1997.atlassian.net/browse/ZH-96

## Key Changes
좋아요 API  호출 관련 코드는 src/apis/like.ts 파일 생성했습니다.
좋아요 상태 관리를 위한 useEffect와 
좋아요 클릭 시 API 호출 되도록 클릭이벤트 구현했습니다.

## 결과물
<img width="1582" alt="스크린샷 2024-11-02 오후 3 22 21" src="https://github.com/user-attachments/assets/828820e9-828e-494a-9005-5e086c2475dd">

## To Reviewers
원래라면 API 요청시에 헤더에 액세스 토큰이 있어야하는 로직인데, 로그인 관련 로직이 없는 관계로
body에 현재 로그인 한 userId를 넣어서 요청을 보내는 형식으로 구현했습니다.
임시 API가 userId가 1일 때 되도록 되어있어서 임시 데이터 1로 지정 해둔 상태입니다. 
로그인 관련 로직이 나온다면 추후에 리팩토링 할 예정이니, useEffect와 클릭 이벤트, api 호출 부분 관련해서 확인 해주세요 !